### PR TITLE
Fixed the scrollTrigger issue on mobile

### DIFF
--- a/src/components/Hero/Hero.css
+++ b/src/components/Hero/Hero.css
@@ -20,6 +20,7 @@
   align-items: center;
   line-height: 1;
   height: 75px;
+  overflow: hidden;
 }
 
 .hero__title {
@@ -61,6 +62,7 @@
   opacity: .5;
   font-size: 14px;
   box-sizing: border-box;
+  overflow: hidden;
 }
 
 @media screen and (max-width: 600px) {


### PR DESCRIPTION
- Apparently fixed the issue of the scrollTrigger not working properly on mobile (the animation was being called right on page load, so the scrollTrigger wasn't doing anything basically).
- It looks like the issue was caused by elements positioned outside of the viewport (during page load, it was possible to scroll the page horizontally and see a white, empty area).
- The way I fixed the issue was by adding "overflow: hidden" to the containers that were overflowing.